### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Aru Sahni <aru@arusahni.net>"]
 edition = "2021"
 license = "MPL-2.0"
-repository = "https://www.github.com/arusahni/qurop"
+repository = "https://github.com/arusahni/qurop"
 keywords = ["x11", "utility", "terminal"]
 categories = ["command-line-utilities"]
 


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96